### PR TITLE
Make the PDF index use the correct not-equal symbol

### DIFF
--- a/category-theory/category-en.tex
+++ b/category-theory/category-en.tex
@@ -347,7 +347,7 @@ It satisfies:
 Verify that $\pmb{Pno}$ is a category.}
 \end{Exercise}
 
-\subsection{Arrow $\neq$ function}
+\subsection{Arrow \texorpdfstring{$\neq$}{≠} function}
 
 In most examples so far, arrows are either functions, or function like things, such as maps or morphisms. It gives us an illusion that arrows mean function like things. The next example helps us to realize such deception. There is a relation category. The objects are sets. The arrow from set $A$ to set $B$, $A \arrowto{R} B$ is defined as:
 

--- a/category-theory/category-zh-cn.tex
+++ b/category-theory/category-zh-cn.tex
@@ -347,7 +347,7 @@ A \arrowto{\phi} B
 试验证$\pmb{Pno}$的确是一个范畴。}
 \end{Exercise}
 
-\subsection{箭头$\neq$函数}
+\subsection{箭头\texorpdfstring{$\neq$}{≠}函数}
 
 在此前的例子中，箭头要么是一般意义上的函数，要么是类似函数意义的映射和态射。这容易造成一种错觉，认为箭头等同于函数。我们接下来看的例子有助于打破这种错觉。有一种名叫关系的范畴。范畴中的对象是集合。从集合$A$到$B$的箭头$A \arrowto{R} B$的定义为：
 


### PR DESCRIPTION
当前生成的 PDF 的目录的 4.1.2 节标题中使用的是等于号而非不等号，中英文版都有相同的问题。

![图片](https://user-images.githubusercontent.com/31474766/99684673-ae372580-2abc-11eb-8c3a-3ef8bf388cc7.png)

解决方法是使用 `\texorpdfstring` 命令以在生成 PDF 元信息时使用 Unicode 字符 “≠”。