### PR TITLE
Redraw figure 6.21 with tikz

### DIFF
--- a/infinity/img/Dedekind-cut.tex
+++ b/infinity/img/Dedekind-cut.tex
@@ -1,0 +1,36 @@
+%% \documentclass{standalone}
+%% \usepackage{amsmath, amsthm, amssymb, amsbsy}
+%% \usepackage{textgreek, upgreek, gensymb, mathtools, extarrows}
+%% \usepackage{tikz}
+%% \usetikzlibrary{patterns,matrix,positioning,shapes}
+%% \begin{document}
+\begin{tikzpicture}[scale = 12, every node/.style={scale=2,inner sep=2pt}]
+  \def\sqrtTwo{2^0.5}
+  %% 两块渐变区域
+  \shade[left color=white, right color=red] (0.97,-0.07) rectangle (\sqrtTwo,0.03);
+  \shade[left color=blue, right color=white] (\sqrtTwo,-0.07) rectangle (2.03,0.03);
+  %% 数轴
+  \draw (0.97,0) -- (2.03,0);
+  %% \sqrt{2} 与虚线
+  \node[below,scale=1.25] at (\sqrtTwo,-0.36) (nsqrt2) {$\mathbf{\sqrt{2}}$};
+  \draw[dashed] (\sqrtTwo, 0.06) -- (nsqrt2);
+  %% 其它数字与实线
+  \def\nlist{%
+    {1/1/(1,-0.3)},%
+    {7/5/(1.05,-0.1)},%
+    {41/29/(1.13,-0.13)},%
+    {239/169/(1.18,-0.25)},%
+    {1393/985/(1.325,-0.15)},%
+    {3363/2378/(1.5,-0.15)},%
+    {577/408/(1.65,-0.25)},%
+    {99/70/(1.7,-0.125)},%
+    {17/12/(1.85,-0.125)},%
+    {3/2/(1.95,-0.1)},%
+    {2/1/(2,-0.3)}%
+  }
+  \foreach \nume / \deno / \pos in \nlist {
+    \node[below] at \pos {$\frac{\nume}{\deno}$};
+    \draw \pos -- (\nume/\deno,0);
+  }
+\end{tikzpicture}
+%% \end{document}

--- a/infinity/infinity-en.tex
+++ b/infinity/infinity-en.tex
@@ -1037,7 +1037,7 @@ Dedekind defined a cut $(A_1, A_2)$, $A_1$ is called `closed downwards', and $A_
 
 \begin{figure}[htbp]
  \centering
- \includegraphics[scale=0.6]{img/Dedekind-cut.png}
+ \subimport{img/}{Dedekind-cut.tex}
  %\captionsetup{labelformat=empty}
  \caption{Define $\sqrt{2}$ with Dedekind cut}
  \label{fig:Dedekind-cut}

--- a/infinity/infinity-zh-cn.tex
+++ b/infinity/infinity-zh-cn.tex
@@ -1002,7 +1002,7 @@ y = 0.01 & 7 & 06 & 8 & 04 & ... \\
 
 \begin{figure}[htbp]
  \centering
- \includegraphics[scale=0.6]{img/Dedekind-cut.png}
+ \subimport{img/}{Dedekind-cut.tex}
  %\captionsetup{labelformat=empty}
  \caption{用戴德金分割构造的$\sqrt{2}$}
  \label{fig:Dedekind-cut}


### PR DESCRIPTION
图 6.21，也就是 `src/infinity/Dedekind-cut.png` 的质量有点低，存在线条太粗、分数不美观的问题，所以我用 tikz 重画了一遍。

绘制效果对比：
![图片](https://user-images.githubusercontent.com/31474766/99884017-f180c800-2c65-11eb-9c81-26e013b9840b.png)

![图片](https://user-images.githubusercontent.com/31474766/99883968-98b12f80-2c65-11eb-84a8-5899bf896d4a.png)


需要把原来的 `src/infinity/Dedekind-cut.png` 删除吗？