### PR TITLE
Improve .gitignore for latexmk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ semantic.cache
 *.pdf
 *.eps
 *.pyc
+*.fdb_latexmk
+*.fls
+*.xdv


### PR DESCRIPTION
latexmk 会产生相应后缀的中间文件，没有加入到 .gitignore 中。