### PR TITLE
Improve CJK font setting

### DIFF
--- a/prelude.sty
+++ b/prelude.sty
@@ -72,6 +72,7 @@
 \usepackage{makeidx} % for index support
 \usepackage{titlesec}
 \usepackage{epigraph}
+\usepackage{ifplatform} % for platform detection
 
 \usepackage{fontspec}
 \usepackage{xunicode}
@@ -250,18 +251,18 @@
   % fc-list :mono       % list all mono fonts
   % fc-cache            % refresh cache to load new installed fonts
 
-  \IfFontExistsTF{STSong}{ % Mac OS X
+  \ifmacosx{ % Mac OS X
     \message{Apply CN font: STSong, STHeiti, STFangsong}
     \setCJKmainfont[BoldFont=STHeiti, ItalicFont=STKaiti]{STSong}
     \setCJKsansfont{STHeiti}
     \setCJKmonofont{STFangsong}
-  }{
-    \IfFontExistsTF{SimSun}{ % Windows
+  }\else{
+    \ifwindows{ % Windows
       \message{Apply CN font: SimSun, SimHei}
       \setCJKmainfont{SimSun}
       \setCJKsansfont{SimHei}
-    }{
-      \IfFontExistsTF{Noto Serif CJK SC}{ % Linux
+    }\else{ % unknown OS
+      \IfFontExistsTF{Noto Serif CJK SC}{ % prefer Noto to the default font Fandol
         \message{Apply CN font: Noto CJK}
         \setCJKmainfont{Noto Serif CJK SC} % (思源宋体)
         \setCJKsansfont{Noto Sans CJK SC}  % (思源黑体)
@@ -269,8 +270,8 @@
       }{
         \message{Apply CN font: xeCJK default Fandol}
       }
-    }
-  }
+    }\fi
+  }\fi
 
   \XeTeXlinebreaklocale "zh"  % to solve the line breaking issue
   \XeTeXlinebreakskip = 0pt plus 1pt minus 0.1pt


### PR DESCRIPTION
在 Linux 上编译时出了问题，目测是因为我导入了 Windows 字体，代码检测到 STSong（华文宋体）存在，所以采用了 Mac OS X 的字体设置，但 STHeiTi 并不存在。

改为用 ifplatform 包检测当前系统。仍使用 `\IfFontExistTF` 检测 Noto 字体，因为 Linux 并不一定安装 Noto 字体。