### PR TITLE
Fix symbols in PDF Labels

### DIFF
--- a/infinity/infinity-en.tex
+++ b/infinity/infinity-en.tex
@@ -421,7 +421,7 @@ For example, $take\ 8\ N = [0, 1, 2, 3, 4, 5, 6, 7]$. There are examples in the 
 \Question{Define $iterate$ by folding.}
 \end{Exercise}
 
-\subsection{Coalgebra and infinite stream$\bigstar$}
+\subsection{Coalgebra and infinite stream\texorpdfstring{$\bigstar$}{★}}
 
 To model the stream of potential infinity, we need the coalgebra concept in category theory introduced in chapter 4. Readers are safe to skip this section in the following 2 pages, and directly read from the next section \textbf{Explore the actual infinity}. Let us first revisit coalgebra and F-morphism.
 

--- a/infinity/infinity-zh-cn.tex
+++ b/infinity/infinity-zh-cn.tex
@@ -419,7 +419,7 @@ take\ n\ cons(x, e)\ = cons(x, take(n-1, e())) \\
 \Question{用叠加操作定义$iterate$。}
 \end{Exercise}
 
-\subsection{余代数和无穷流$\bigstar$}
+\subsection{余代数和无穷流\texorpdfstring{$\bigstar$}{★}}
 
 本小节给出无穷流的数学解释，它需要使用第四章范畴论中介绍的余代数概念。一般的读者可以跳过两页直接阅读下一节\textbf{关于实无穷的思考}。首先我们回顾一下余代数和F-态射的概念。
 

--- a/recursion/recursion-en.tex
+++ b/recursion/recursion-en.tex
@@ -623,7 +623,7 @@ It's interesting that the incommensurable is defined by checking whether the Euc
 \Question{For the regular pentagon with side of 1, how long is the diagonal? Proof that in the pentagram shown in figure \ref{fig:pentagram}, the segment $AC$ and $AG$ are incommensurable. What's their ratio in real number?}
 \end{Exercise}
 
-\section{The $\lambda$ calculus}
+\section{The \texorpdfstring{$\lambda$}{λ} calculus}
 
 Recursion would not be a problem if performed by human. As the intelligent beings, we are able to enter the next level of computation when meet recursion, and return back to the upper level after that. However, it matters when instruct machine to compute. Several computation models were developed in 1930s independently. The most famous ones are Turing machine (1935 by Turing), $\lambda$-calculus (1932 - 1941 by Church, and 1935 by Stephen Kleene. The Greek letter $\lambda$ is pronounced as lambda), and recursive function (1934 by Jacques Herbrand and Kurt Gödel).
 
@@ -683,7 +683,7 @@ tail\ (cons\ a\ b) \mapsto b
 \end{array}
 \]
 
-\subsection{$\lambda$ abstraction}
+\subsection{\texorpdfstring{$\lambda$}{λ} abstraction}
 
 We told the story about how $\lambda$ symbol was introduced. $\lambda$ abstraction is a method to construct function. Let's use an example to understand every component in $\lambda$ abstraction.
 
@@ -710,7 +710,7 @@ We'll also use the equivalent $x \mapsto x + 1$ form for convenience. Note that 
         & | & $\lambda$ <variable> . <exp> & $\lambda$ abstraction
 \end{tabular}
 
-\subsection{$\lambda$ conversion rules}
+\subsection{\texorpdfstring{$\lambda$}{λ} conversion rules}
 
 When evaluate the below $\lambda$ expression, we need to know the value for the global variable $y$. On the other hand, we needn't know the value of variable $x$, because it appears as the formal parameter.
 
@@ -1004,7 +1004,7 @@ Y\ (f \mapsto (n \mapsto \textbf{if}\ n = 0\ \textbf{then}\ 1\ \textbf{else}\ n 
 
 It is more significant in mathematics than in practice to define $Y$ in $\lambda$ abstraction. $Y$ is often realized as a built-in function in real environment, which directly converts $Y\ H$ to $H\ (Y\ H)$.
 
-\section{The impact of $\lambda$ calculus}
+\section{The impact of \texorpdfstring{$\lambda$}{λ} calculus}
 
 The significant of the $\lambda$ calculus is that it models the complex computation process with a set of simple rules. Consider the way of representing the Euclidean algorithm in $\lambda$ expressions, then perform $\beta$-reduction to evaluate the result, it's feasible although looks complex from realization perspective. It does not limit to Euclidean algorithm, but can represents any computable functions. People later proved that $\lambda$ calculus and Turing machine are equivalent. One advantage of $\lambda$ calculus is that it only uses the traditional function concept in mathematics. People used it in 1930s to formalize the metamathematics. However, Kleene and Rosser proved that the original lambda calculus was inconsistent in 1935. Subsequently, in 1936 Church isolated and published just the portion relevant to computation, what is now called the untyped lambda calculus. In 1940, he also introduced a computationally weaker, but logically consistent system, known as the simply typed lambda calculus.
 

--- a/recursion/recursion-zh-cn.tex
+++ b/recursion/recursion-zh-cn.tex
@@ -629,7 +629,7 @@ jars a b c = (x, y) where
 \Question{边长为1的正五边形，对角线的长度是多少？试证明图\ref{fig:pentagram}的五角星中的线段AC和AG是不可公度的。使用实数表示，它们的比值是什么？}
 \end{Exercise}
 
-\section{$\lambda$演算}
+\section{\texorpdfstring{$\lambda$}{λ}演算}
 
 如果进行计算的是如我们人类这样的智慧生命，也许不用深究递归的原理。我们只需要进行计算，发现递归时就在自己的思维中螺旋进入下一个层次。当递归终止时，就退回上一层。当人们思考如何用机器帮助我们进行计算时，这一问题才变得重要起来。二十世纪三十年代，当人们在研究可计算问题时，分别独立提出了一些计算模型。最著名的包括图灵提出的图灵机模型（1935年），丘奇（1932到1941年）和克莱尼（Stephen Kleene，1935年）提出的$\lambda$演算(希腊字母$\lambda$读作lambda)，埃尔布朗（Jacques Herbrand）和哥德尔（Kurt Gödel）提出的递归函数（1934年）等。
 
@@ -687,7 +687,7 @@ tail\ (cons\ a\ b) \mapsto b
 \end{array}
 \]
 
-\subsection{$\lambda$抽象}
+\subsection{\texorpdfstring{$\lambda$}{λ}抽象}
 \index{lambda抽象}
 我们前面简单介绍了$\lambda$符号的由来，所谓$\lambda$抽象，实际上是一种构建函数的方法。我们通过一个例子来了解$\lambda$抽象的各个组成部分。
 
@@ -712,7 +712,7 @@ $\uparrow$ & $\uparrow$ & $\uparrow$ & $\uparrow$ \\
         & | & $\lambda$ <变量> . <表达式> & $\lambda$抽象
 \end{tabular}
 
-\subsection{$\lambda$变换规则}
+\subsection{\texorpdfstring{$\lambda$}{λ}变换规则}
 
 考虑下面的$\lambda$表达式，如果对它化简，我们需要知道“全局”变量$y$的值。与之相对，我们不需要事先知道变量$x$的值，因为它以形参出现在函数中。
 
@@ -1010,7 +1010,7 @@ Y\ (f \mapsto (n \mapsto \textbf{if}\ n = 0\ \textbf{then}\ 1\ \textbf{else}\ n 
 
 用$\lambda$-抽象来定义$Y$的数学意义远大于其实现的意义。在真实的环境中，通常$Y$被内置实现为函数，可以直接将$Y\ H$转化为$H\ (Y\ H)$。
 
-\section{$\lambda$演算的意义}
+\section{\texorpdfstring{$\lambda$}{λ}演算的意义}
 
 $\lambda$演算的意义在于，它用一组简单的规则对复杂的计算过程进行了定义。将欧几里得算法用$\lambda$演算表示出来，再利用$\beta$规约进行计算。这样的实现可能比较复杂，但确实可行。它不仅可以表达欧几里得算法，而且适用于所有的可计算函数。图灵后来证明了$\lambda$演算与图灵机的等价性。$\lambda$演算的一大优势在于它仅仅使用了传统的数学概念——函数。因而在十九世纪30年代，$\lambda$演算被用来对数学进行形式化。然而在1935年，克莱尼-罗瑟悖论证明了最初的$\lambda$形式系统在逻辑上是不一致的。1936年，丘奇将$\lambda$演算模型中和纯计算有关的部分分离出来，称为的无类型$\lambda$演算。1940年时，丘奇又提出了一个弱化计算，但是逻辑自洽的形式系统，被称之为简单类型$\lambda$演算。
 


### PR DESCRIPTION
同 #24。通过在构建日志中搜索 `PDF String` 得到全部不正确的PDF标签。