### PR TITLE
fix a typo in the definition of monoid group.

### DIFF
--- a/algebra/algebra-en.tex
+++ b/algebra/algebra-en.tex
@@ -291,7 +291,7 @@ The criteria to be a group is a bit strict. From the negative examples in previo
 A \textbf{monoid} is a set $S$ together with a binary operation `$\cdot$', which satisfies two axioms:
 \begin{enumerate}
 \item \textbf{Associativity}: For any three elements in $S$, the equation $(a \cdot b) \cdot c = a \cdot (b \cdot c)$ holds.
-\item \textbf{Identity element}: There exists an element $e$ in $S$, such that for every element $a$ in $S$, the equation $a \cdot e = e \cdot a = e$ holds.
+\item \textbf{Identity element}: There exists an element $e$ in $S$, such that for every element $a$ in $S$, the equation $a \cdot e = e \cdot a = a$ holds.
 \end{enumerate}
 \end{definition}
 

--- a/algebra/algebra-zh-cn.tex
+++ b/algebra/algebra-zh-cn.tex
@@ -278,7 +278,7 @@ build = foldr(nil, insert)
 \textbf{幺半群}是一个集合$S$和其上定义的二元运算$\cdot$，它们遵循两条公理：
 \begin{enumerate}
 \item 结合性公理：$S$中和任何三个元素满足$(a \cdot b) \cdot c = a \cdot (b \cdot c)$；
-\item 单位元公理：$S$中存在一个元素$e$，使得对任何$a \cdot e = e \cdot a = e$。
+\item 单位元公理：$S$中存在一个元素$e$，使得对任何$a \cdot e = e \cdot a = a$。
 \end{enumerate}
 \end{definition}
 


### PR DESCRIPTION
The definition of monoid group should $a \cdot e = e \cdot a = a$ not $a \cdot e = e \cdot a = e$, which does not make sense. 

Please take a look and consider a pulling