### PR TITLE
Fix a typo

### DIFF
--- a/algebra/algebra-zh-cn.tex
+++ b/algebra/algebra-zh-cn.tex
@@ -1885,7 +1885,7 @@ a^{\upphi(n)} = e
   & \textbf{1} & 2 & \textbf{3} & 4 & 5 & 6 & \textbf{7} & 8 & \textbf{9} \\
 \hline
 \rowcolor{Gray}
-\textbf{1} & \cellcolor{gray} \underline{1} & 2 & 3 & 4 & 5 & 6 & 7 & 8 & 8 \\
+\textbf{1} & \cellcolor{gray} \underline{1} & 2 & 3 & 4 & 5 & 6 & 7 & 8 & 9 \\
 \hline
 2 & 2 & 4 & 6 & 8 & 0 & 2 & 4 & 6 & 8 \\
 \hline


### PR DESCRIPTION
"\textbf{1} & \cellcolor{gray} \underline{1} & 2 & 3 & 4 & 5 & 6 & 7 & 8 & 8 \\" should be 
"\textbf{1} & \cellcolor{gray} \underline{1} & 2 & 3 & 4 & 5 & 6 & 7 & 8 & 9 \\"